### PR TITLE
Persist log across app launches

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -58,4 +58,11 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.robolectric:robolectric:4.2.1'
     testImplementation 'androidx.test:core:1.2.0'
+
+    def room_version = "2.2.5"
+
+    implementation "androidx.room:room-runtime:$room_version"
+    annotationProcessor "androidx.room:room-compiler:$room_version"
+
+    testImplementation "androidx.room:room-testing:$room_version"
 }

--- a/app/src/main/java/com/example/drivescience/AppDatabase.java
+++ b/app/src/main/java/com/example/drivescience/AppDatabase.java
@@ -1,0 +1,11 @@
+package com.example.drivescience;
+
+import androidx.room.Database;
+import androidx.room.RoomDatabase;
+import androidx.room.TypeConverters;
+
+@Database(entities = {LogMessage.class}, version = 1)
+@TypeConverters({DateConverter.class})
+public abstract class AppDatabase extends RoomDatabase {
+    public abstract LogMessageDao logMessageDao();
+}

--- a/app/src/main/java/com/example/drivescience/DateConverter.java
+++ b/app/src/main/java/com/example/drivescience/DateConverter.java
@@ -1,0 +1,21 @@
+package com.example.drivescience;
+
+import androidx.room.TypeConverter;
+
+import java.util.Date;
+
+public class DateConverter {
+    @TypeConverter
+    public Date fromTimestamp(Long timestamp) {
+        return timestamp == null ? null : new Date(timestamp);
+    }
+
+    @TypeConverter
+    public Long dateToTimestamp(Date date) {
+        if (date == null) {
+            return null;
+        } else {
+            return date.getTime();
+        }
+    }
+}

--- a/app/src/main/java/com/example/drivescience/LogMessage.java
+++ b/app/src/main/java/com/example/drivescience/LogMessage.java
@@ -1,0 +1,19 @@
+package com.example.drivescience;
+
+import androidx.room.ColumnInfo;
+import androidx.room.Entity;
+import androidx.room.PrimaryKey;
+
+import java.util.Date;
+
+@Entity
+public class LogMessage {
+    @PrimaryKey(autoGenerate = true)
+    public int uid;
+
+    @ColumnInfo(name = "message")
+    public String message;
+
+    @ColumnInfo(name = "date")
+    public Date date;
+}

--- a/app/src/main/java/com/example/drivescience/LogMessageDao.java
+++ b/app/src/main/java/com/example/drivescience/LogMessageDao.java
@@ -1,0 +1,23 @@
+package com.example.drivescience;
+
+import androidx.room.Dao;
+import androidx.room.Delete;
+import androidx.room.Insert;
+import androidx.room.Query;
+
+import java.util.List;
+
+@Dao
+public interface LogMessageDao {
+    @Query("SELECT * FROM logmessage ORDER BY uid")
+    List<LogMessage> getAll();
+
+    @Insert
+    void insert(LogMessage logMessage);
+
+    @Delete
+    void delete(LogMessage logMessage);
+
+    @Query("DELETE FROM logmessage")
+    void deleteAll();
+}


### PR DESCRIPTION
Takes advantage of the questionably-named Room persistence library to store log and display messages until explicitly cleared by the user. Also stops using `LocalDateTime` in favor of `Date`. This is due to date time on Android being a mess.