### PR TITLE
Do not create notification on OnClearFromRecentService start

### DIFF
--- a/app/src/main/java/com/example/drivescience/OnClearFromRecentService.java
+++ b/app/src/main/java/com/example/drivescience/OnClearFromRecentService.java
@@ -29,7 +29,6 @@ public class OnClearFromRecentService extends Service {
         NotificationManagerCompat notificationManager = NotificationManagerCompat.from(this);
         notificationManager.cancel(NOTIFICATION_ID);
 
-        createNotification();
         return START_NOT_STICKY;
     }
 


### PR DESCRIPTION
at the start of the `OnClearFromRecentService` we create the notification telling the user we can't track trips. We only want to show this notification when the service is removed (signaling the killing of the app)