### PR TITLE
Updates notification text in OnClearFromRecentService

### DIFF
--- a/app/src/main/java/com/example/drivescience/OnClearFromRecentService.java
+++ b/app/src/main/java/com/example/drivescience/OnClearFromRecentService.java
@@ -48,8 +48,8 @@ public class OnClearFromRecentService extends Service {
 
         NotificationCompat.Builder builder = new NotificationCompat.Builder(this, NOTIFICATION_CHANNEL_ID)
                 .setSmallIcon(R.drawable.ic_driving_notification)
-                .setContentTitle("Cannot track trips!")
-                .setContentText("App has been killed, can no longer track trips. Re-open the app to allow for trip tracking")
+                .setContentTitle("App removed from recents!")
+                .setContentText("App has been removed from the recents menu, trip tracking may not behave as expected!")
                 .setContentIntent(pendingIntent)
                 .setPriority(NotificationCompat.PRIORITY_DEFAULT);
 


### PR DESCRIPTION
We do not expect the trip tracker to not be able to track trips when an app is cleared from recents. This updates the example notification to make this text more generic